### PR TITLE
Updated Java build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please read the [guide](https://github.com/CyberdyneCC/Thermos/blob/master/CONTR
 
 
 ## Build Requirements
-* Java 8 JDK
+* Java 8u101 JDK or higher
 * `JAVA_HOME` defined on your OS
 
 ## Building CyberdyneCC/Thermos


### PR DESCRIPTION
Required to add Lets Encrypt as default keychain within JDK without needing to use `keychain`
References: https://twitter.com/letsencrypt/status/755496097435361280 & http://www.oracle.com/technetwork/java/javase/8u101-relnotes-3021761.html